### PR TITLE
Feature/camera rotation fix

### DIFF
--- a/common/config_util.cpp
+++ b/common/config_util.cpp
@@ -109,6 +109,12 @@ static float jsonGetFloat(const std::string& json, const std::string& key, float
     try { return std::stof(s); } catch (...) { return defVal; }
 }
 
+static int jsonGetInt(const std::string& json, const std::string& key, int defVal) {
+    auto s = jsonGetString(json, key);
+    if (s.empty()) return defVal;
+    try { return std::stoi(s); } catch (...) { return defVal; }
+}
+
 std::string ConfigToJson(const AppConfig& cfg) {
     std::ostringstream ss;
     ss << "{\n";
@@ -119,6 +125,7 @@ std::string ConfigToJson(const AppConfig& cfg) {
     ss << "  "; jsonWriteString(ss, "anti_spoof_threshold"); ss << ": " << cfg.anti_spoof_threshold << ",\n";
     ss << "  "; jsonWriteString(ss, "blink_glasses_mode"); ss << ": " << (cfg.blink_glasses_mode ? "true" : "false") << ",\n";
     ss << "  "; jsonWriteString(ss, "low_light_enhance"); ss << ": " << (cfg.low_light_enhance ? "true" : "false") << ",\n";
+    ss << "  "; jsonWriteString(ss, "camera_rotation"); ss << ": " << cfg.camera_rotation << ",\n";
     ss << "  "; jsonWriteString(ss, "camera_device"); ss << ": "; jsonWriteString(ss, cfg.camera_device); ss << "\n";
     ss << "}\n";
     return ss.str();
@@ -136,6 +143,7 @@ AppConfig ConfigFromJson(const std::string& json) {
     cfg.anti_spoof_threshold = jsonGetFloat(json, "anti_spoof_threshold", 0.30f);
     cfg.blink_glasses_mode = (jsonGetString(json, "blink_glasses_mode") == "true");
     cfg.low_light_enhance = (jsonGetString(json, "low_light_enhance") == "true");
+    cfg.camera_rotation = jsonGetInt(json, "camera_rotation", 0);
     auto cam = jsonGetString(json, "camera_device");
     if (!cam.empty()) cfg.camera_device = cam;
     return cfg;
@@ -175,10 +183,11 @@ AppConfig LoadConfig(const std::wstring& dataDir) {
     file.close();
 
     AppConfig cfg = ConfigFromJson(buf.str());
-    FACELOGIN_INFO(L"Loaded config.json: rec=%hs det=%hs live=%hs thr=%.2f camera=%hs",
+    FACELOGIN_INFO(L"Loaded config.json: rec=%hs det=%hs live=%hs thr=%.2f camera=%hs rotation=%d",
                   cfg.recognition_model.c_str(), cfg.detector.c_str(),
                   LivenessMethodToString(cfg.liveness_method).c_str(),
-                  cfg.match_threshold, cfg.camera_device.c_str());
+                  cfg.match_threshold, cfg.camera_device.c_str(),
+                  cfg.camera_rotation);
     return cfg;
 }
 

--- a/common/config_util.h
+++ b/common/config_util.h
@@ -23,6 +23,10 @@ struct AppConfig {
     // anti-spoof, so matches/scores don't degrade in dark scenes.
     bool           low_light_enhance      = false;
     std::string    camera_device          = "";          // device symbolic link; empty = first camera
+    // Camera rotation in degrees clockwise. Valid: 0, 90, 180, 270.
+    // Use when the camera is physically mounted in a non-standard
+    // orientation (e.g., vertical PC mount / sideways webcam).
+    int            camera_rotation        = 0;
 };
 
 AppConfig LoadConfig(const std::wstring& dataDir);

--- a/common/image_utils.h
+++ b/common/image_utils.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <dlib/matrix.h>
+#include <dlib/pixel.h>
+
+namespace facelogin {
+
+/// Rotate a dlib RGB image clockwise by 0, 90, 180, or 270 degrees.
+/// Other values are silently treated as 0 (no-op).
+/// Frame dimensions swap accordingly for 90/270.
+inline void RotateFrame(dlib::matrix<dlib::rgb_pixel>& frame, int rotation) {
+    if (rotation == 0) return;
+
+    long h = frame.nr();
+    long w = frame.nc();
+
+    if (rotation == 180) {
+        dlib::matrix<dlib::rgb_pixel> out(h, w);
+        for (long y = 0; y < h; ++y)
+            for (long x = 0; x < w; ++x)
+                out(y, x) = frame(h - 1 - y, w - 1 - x);
+        frame = std::move(out);
+    } else if (rotation == 90) {
+        dlib::matrix<dlib::rgb_pixel> out(w, h);
+        for (long y = 0; y < w; ++y)
+            for (long x = 0; x < h; ++x)
+                out(y, x) = frame(h - 1 - x, y);
+        frame = std::move(out);
+    } else if (rotation == 270) {
+        dlib::matrix<dlib::rgb_pixel> out(w, h);
+        for (long y = 0; y < w; ++y)
+            for (long x = 0; x < h; ++x)
+                out(y, x) = frame(x, w - 1 - y);
+        frame = std::move(out);
+    }
+}
+
+} // namespace facelogin

--- a/enrollment_app/EnrollmentWizard.cpp
+++ b/enrollment_app/EnrollmentWizard.cpp
@@ -4,6 +4,7 @@
 #include "../common/ipc_protocol.h"
 #include "../common/registry_util.h"
 #include "../common/config_util.h"
+#include "../common/image_utils.h"
 #include <comdef.h>
 #include <shlobj.h>
 #include <wincodec.h>
@@ -327,6 +328,8 @@ bool EnrollmentWizard::StartPreview() {
                 std::this_thread::sleep_for(std::chrono::milliseconds(5));
                 continue;
             }
+
+            RotateFrame(frame, m_config.camera_rotation);
 
             std::string b64 = EncodeJPEGBase64(frame);
             // Preview overlay: detect the face with SCRFD and show its box.
@@ -1291,10 +1294,10 @@ bool EnrollmentWizard::SetConfig(const std::string& json) {
         CloseHandle(hPipe);
     }
 
-    FACELOGIN_INFO(L"Configuration updated: rec=%hs det=%hs live=%hs thr=%.2f",
+    FACELOGIN_INFO(L"Configuration updated: rec=%hs det=%hs live=%hs thr=%.2f rotation=%d",
                   m_config.recognition_model.c_str(), m_config.detector.c_str(),
                   LivenessMethodToString(m_config.liveness_method).c_str(),
-                  m_config.match_threshold);
+                  m_config.match_threshold, m_config.camera_rotation);
 
     // If the camera selection changed and the preview is running, restart the
     // preview so the new camera takes effect immediately.

--- a/enrollment_app/index.html
+++ b/enrollment_app/index.html
@@ -331,6 +331,17 @@ body{
          dlib was dropped, the system is now pure ONNX (InsightFace + SCRFD). -->
 
     <div class="field">
+      <label>摄像头旋转 (Camera Rotation)</label>
+      <select id="cfg-rotation">
+        <option value="0">不旋转 (0°)</option>
+        <option value="90">顺时针 90°</option>
+        <option value="180">180°</option>
+        <option value="270">顺时针 270°</option>
+      </select>
+      <p class="dim" style="margin-top:4px;font-size:11px">摄像头物理安装方向不是正向上时（如竖屏安装），可在此调整。实时预览会立即反映旋转效果。</p>
+    </div>
+
+    <div class="field">
       <label>摄像头 (Camera)</label>
       <select id="cfg-camera">
         <option value="">默认（第一个设备）</option>
@@ -572,6 +583,7 @@ function loadSettings() {
     var json = H.GetConfig();
     var cfg = JSON.parse(json);
     document.getElementById('cfg-liveness').value = cfg.liveness_method || 'blink';
+    document.getElementById('cfg-rotation').value = String(cfg.camera_rotation || 0);
     document.getElementById('cfg-blink-glasses').checked = !!cfg.blink_glasses_mode;
     document.getElementById('cfg-low-light').checked = !!cfg.low_light_enhance;
 
@@ -626,6 +638,7 @@ function onSaveSettings() {
     anti_spoof_threshold: parseFloat(document.getElementById('cfg-antispoof-threshold').value) / 100,
     blink_glasses_mode: document.getElementById('cfg-blink-glasses').checked,
     low_light_enhance: document.getElementById('cfg-low-light').checked,
+    camera_rotation: parseInt(document.getElementById('cfg-rotation').value) || 0,
     camera_device: document.getElementById('cfg-camera').value
   };
   try {

--- a/face_service/FaceService.cpp
+++ b/face_service/FaceService.cpp
@@ -4,6 +4,7 @@
 #include "../common/secure_buffer.h"
 #include "../common/registry_util.h"
 #include "../common/config_util.h"
+#include "../common/image_utils.h"
 #include "liveness_detector.h"
 #include <shlobj.h>
 #include <chrono>
@@ -256,11 +257,11 @@ bool FaceService::Initialize() {
         FACELOGIN_INFO(L"DirectShow webcam will be initialized on demand%s",
                        m_config.camera_device.empty() ? L"" : L" (configured device)");
     } else {
-        m_webcamMF = std::make_unique<WebcamCapture>();
-        if (!m_webcamMF->Initialize(1280, 720, Utf8ToWstr(m_config.camera_device))) {
-            FACELOGIN_ERROR(L"Failed to initialize MF webcam");
-            return false;
-        }
+        // Media Foundation camera is also initialized on demand — keeping
+        // it open across auth sessions causes the source reader to stall
+        // (especially when FaceLoginConsole is running concurrently).
+        FACELOGIN_INFO(L"MF webcam will be initialized on demand%s",
+                       m_config.camera_device.empty() ? L"" : L" (configured device)");
     }
 
     m_pipeServer = std::make_unique<PipeServer>();
@@ -332,11 +333,11 @@ void FaceService::Run() {
             if (m_antiSpoof) m_antiSpoof->SetLowLightEnhance(m_config.low_light_enhance);
             m_pipeServer->WriteMessage(ipc::MSG_CONFIG_RELOAD_OK);
             m_pipeServer->Disconnect();
-            FACELOGIN_INFO(L"Configuration reloaded: rec=%hs det=%hs live=%hs thr=%.2f",
+            FACELOGIN_INFO(L"Configuration reloaded: rec=%hs det=%hs live=%hs thr=%.2f rotation=%d",
                           m_config.recognition_model.c_str(), m_config.detector.c_str(),
                           m_livenessMethod == LivenessMethod::Blink ? "blink" :
                           m_livenessMethod == LivenessMethod::AntiSpoof ? "antispoof" : "none",
-                          m_matchThreshold);
+                          m_matchThreshold, m_config.camera_rotation);
         }
         else if (request == ipc::MSG_GET_LOGS) {
             auto lines = Logger::Instance().GetRecentLogs(500);
@@ -371,12 +372,31 @@ void FaceService::Run() {
                     }
                     FACELOGIN_INFO(L"DS camera initialized on demand for auth");
                 }
+            } else {
+                if (!m_webcamMF) {
+                    m_webcamMF = std::make_unique<WebcamCapture>();
+                    if (!m_webcamMF->Initialize(1280, 720, Utf8ToWstr(m_config.camera_device))) {
+                        FACELOGIN_ERROR(L"MF camera init failed on demand");
+                        m_webcamMF.reset();
+                        m_pipeServer->WriteMessage(ipc::BuildAuthErrorMessage(L"摄像头不可用"));
+                        FlushFileBuffers(m_pipeServer->GetHandle());
+                        m_pipeServer->DrainOutput(5000);
+                        m_pipeServer->Disconnect();
+                        continue;
+                    }
+                    FACELOGIN_INFO(L"MF camera initialized on demand for auth");
+                }
             }
             ProcessAuthRequest();
             if (m_isServiceMode && m_webcamDS) {
                 m_webcamDS->Shutdown();
                 m_webcamDS.reset();
                 FACELOGIN_INFO(L"DS camera released after auth");
+            }
+            if (!m_isServiceMode && m_webcamMF) {
+                m_webcamMF->Shutdown();
+                m_webcamMF.reset();
+                FACELOGIN_INFO(L"MF camera released after auth");
             }
             m_pipeServer->Disconnect();
         }
@@ -472,6 +492,8 @@ bool FaceService::ProcessAuthRequest() {
             std::this_thread::sleep_for(std::chrono::milliseconds(30));
             continue;
         }
+
+        RotateFrame(frame, m_config.camera_rotation);
 
         // Face detection + landmarks: SCRFD detects, dlib shape predictor
         // (GetLandmarks) extracts 68 points for alignment + blink.


### PR DESCRIPTION
## Summary

  ### 1. Camera Rotation Support (`camera_rotation` config)
  - 新增 `camera_rotation` 配置项 (0/90/180/270
  顺时针)，解决竖屏/侧装摄像头场景下的人脸识别失败问题
  - 新增 `common/image_utils.h`: `RotateFrame()` 像素级旋转辅助函数
  - 录入应用 (`EnrollmentWizard`) 和服务端 (`FaceService`)
  均在抓帧后立即应用旋转，覆盖预览、检测、采集全流程
  - 设置页新增「摄像头旋转」下拉菜单，实时预览即时反映效果

  ### 2. MF Camera On-Demand Lifecycle Fix
  - 修复 standalone 模式下 Media Foundation 摄像头只在启动时初始化一次、永不释放的问题
  - 改为和 DirectShow (service mode) 相同的「按需初始化 → 认证 → 释放」模式
  - 解决了第二次及后续锁屏时摄像头 LED 不亮、无法识别的问题

  ### Files Changed
  | File | Change |
  |---|---|
  | `common/config_util.h` | Add `int camera_rotation = 0` to `AppConfig` |
  | `common/config_util.cpp` | Serialize/deserialize `camera_rotation`, update logs |
  | `common/image_utils.h` (new) | `RotateFrame()` helper for 90/180/270-degree rotation |
  | `face_service/FaceService.cpp` | Apply rotation after grab; lazy-init/shutdown MF camera |
  | `enrollment_app/EnrollmentWizard.cpp` | Apply rotation in frame thread |
  | `enrollment_app/index.html` | Rotation dropdown in settings UI |

  ### Backward Compatibility
  - `camera_rotation` defaults to `0` — no rotation, identical to previous behavior
  - Existing `config.json` files without the field are handled gracefully (`jsonGetInt`
  returns 0)