### PR TITLE
fix(security): 修复 MSA 身份误判误报

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ vcpkg/
 # Model files (large, downloaded separately)
 models/*.dat
 models/*.bz2
+*.onnx
 
 # IDE / VS
 .vs/
@@ -40,6 +41,7 @@ __pycache__/
 
 # Claude Code
 .claude/
+CLAUDE.md
 
 # Wails
 installer/FaceLoginSetup/build/

--- a/credential_provider/FaceLoginProvider.cpp
+++ b/credential_provider/FaceLoginProvider.cpp
@@ -394,7 +394,15 @@ static std::wstring GetMSAUpnFromIdentityStore(const std::wstring& userSid) {
                 RegQueryValueExW(hEntry, L"Sid", nullptr, nullptr,
                     reinterpret_cast<LPBYTE>(sidValue), &sidSize);
 
-                if (identityName[0] != L'\0' && wcschr(identityName, L'@')) {
+                // Only adopt the email when it is genuinely linked to the
+                // requested user SID. The cache holds MSA identities for ALL
+                // accounts ever seen on the machine (other profiles, previous
+                // users, or an MSA later converted to local); taking the first
+                // email found would misattribute it to the wrong user (same
+                // class of bug as docs/todo.md bug1).
+                if (identityName[0] != L'\0' && wcschr(identityName, L'@') &&
+                    !userSid.empty() && sidValue[0] != L'\0' &&
+                    wcscmp(sidValue, userSid.c_str()) == 0) {
                     upn = identityName;
                     FACELOGIN_INFO(L"MSA UPN found in IdentityStore: %s (SID=%s)",
                                   identityName, sidValue);

--- a/enrollment_app/EnrollmentWizard.cpp
+++ b/enrollment_app/EnrollmentWizard.cpp
@@ -55,9 +55,24 @@ static std::wstring GetSessionUpn() {
     auto pfn = reinterpret_cast<PFN_GetUserNameExW>(
         GetProcAddress(hSecur32, "GetUserNameExW"));
     if (pfn) {
+        // GetUserNameExW returns ERROR_INSUFFICIENT_BUFFER (122) and writes
+        // the REQUIRED size (in wchar, INCLUDING the terminator) back into
+        // *upnSize when the buffer is too small. A single 256-char probe
+        // would silently drop over-long UPNs (very long domains / AD UPNs),
+        // mislabeling the account as local — the same class of bug as
+        // docs/todo.md bug1, just the symmetric case. Retry once with the
+        // required size; ERROR_NONE_MAPPED (1332, local accounts) leaves
+        // upn empty as intended.
         ULONG upnSize = 256;
         std::vector<wchar_t> upnBuf(upnSize);
-        if (pfn(8 /* NameUserPrincipal */, upnBuf.data(), &upnSize)) {
+        if (!pfn(8 /* NameUserPrincipal */, upnBuf.data(), &upnSize)) {
+            if (GetLastError() == ERROR_INSUFFICIENT_BUFFER && upnSize > 0) {
+                upnBuf.resize(upnSize);
+                if (pfn(8 /* NameUserPrincipal */, upnBuf.data(), &upnSize)) {
+                    upn = upnBuf.data();
+                }
+            }
+        } else {
             upn = upnBuf.data();
         }
     }
@@ -646,13 +661,27 @@ static std::string WstrToUtf8(const std::wstring& ws) {
     return result;
 }
 
-// Helper: UTF-8 string with JSON escaping (quotes, backslashes) — safe to
-// embed directly inside a JSON string literal for the face list.
+// Helper: UTF-8 string with JSON escaping — safe to embed directly inside a
+// JSON string literal for the face list and account-change responses. Escapes
+// per RFC 8259: quote, backslash, and the mandatory control characters
+// (U+0000–U+001F). Forward slash is intentionally NOT escaped (legal in JSON
+// and never needed for these fields). Other characters pass through UTF-8.
 static std::string WstrToUtf8Escaped(const std::wstring& ws) {
+    static const char* kHex = "0123456789abcdef";
     std::string out;
     for (wchar_t ch : ws) {
-        if (ch == L'"')       out += "\\\"";
-        else if (ch == L'\\') out += "\\\\";
+        if (ch == L'"')            out += "\\\"";
+        else if (ch == L'\\')      out += "\\\\";
+        else if (ch == L'\b')      out += "\\b";
+        else if (ch == L'\f')      out += "\\f";
+        else if (ch == L'\n')      out += "\\n";
+        else if (ch == L'\r')      out += "\\r";
+        else if (ch == L'\t')      out += "\\t";
+        else if (ch < 0x20) {      // other C0 control chars → \uXXXX
+            out += "\\u00";
+            out += kHex[(ch >> 4) & 0xF];
+            out += kHex[ch & 0xF];
+        }
         else {
             char mb[4] = {};
             int n = WideCharToMultiByte(CP_UTF8, 0, &ch, 1, mb, 4, nullptr, nullptr);
@@ -1140,9 +1169,16 @@ bool EnrollmentWizard::ClearStaleAccountUpn() {
         return false;
     }
 
+    // FindUserIndex tries SID first, then UPN, then username. We pass an
+    // EMPTY upn on purpose: m_upn is the value we are about to clear (the
+    // stale MSA email that a buggy build wrote into a local record), so
+    // matching by it would be circular and could pick another account's
+    // record if SIDs ever collided. The process-token SID is the trusted
+    // identity proof here (same source as passwordless enrollment), and
+    // username is kept as a last-resort fallback. See docs/todo.md bug1.
     std::wstring tokenSid = GetCurrentProcessUserSid();
     m_store.LoadDatabase();
-    size_t idx = m_store.FindUserIndex(tokenSid, m_upn, m_username);
+    size_t idx = m_store.FindUserIndex(tokenSid, L"", m_username);
     if (idx >= m_store.GetUsers().size()) {
         FACELOGIN_WARN(L"ClearStaleAccountUpn: record vanished before update");
         return false;

--- a/enrollment_app/EnrollmentWizard.cpp
+++ b/enrollment_app/EnrollmentWizard.cpp
@@ -34,6 +34,37 @@ static std::wstring Utf8ToWstr(const std::string& s) {
     return ws;
 }
 
+// ---------------------------------------------------------------------------
+// Session identity helper
+//
+// GetUserNameExW(NameUserPrincipal) is the ONE authoritative source of the
+// current session's UPN: it returns the email for Microsoft accounts and
+// fails with ERROR_NONE_MAPPED (1332) for local accounts. Machine-wide
+// registry caches (IdentityStore\LogonCache\Name2Sid etc.) can hold MSA
+// identities that do NOT belong to the current user — a previous user
+// profile, or an MSA that was later converted to local. Adopting one of
+// those emails mislabels the account as MSA and poisons the stored record,
+// which produced bug1's perpetual false "账号身份已变更" prompt. All
+// MSA/local decisions must route through GetSessionUpn().
+// ---------------------------------------------------------------------------
+static std::wstring GetSessionUpn() {
+    std::wstring upn;
+    HMODULE hSecur32 = LoadLibraryW(L"secur32.dll");
+    if (!hSecur32) return upn;
+    typedef BOOLEAN (WINAPI *PFN_GetUserNameExW)(int, LPWSTR, PULONG);
+    auto pfn = reinterpret_cast<PFN_GetUserNameExW>(
+        GetProcAddress(hSecur32, "GetUserNameExW"));
+    if (pfn) {
+        ULONG upnSize = 256;
+        std::vector<wchar_t> upnBuf(upnSize);
+        if (pfn(8 /* NameUserPrincipal */, upnBuf.data(), &upnSize)) {
+            upn = upnBuf.data();
+        }
+    }
+    FreeLibrary(hSecur32);
+    return upn;
+}
+
 EnrollmentWizard::EnrollmentWizard() {
     std::wstring regData = ReadRegString(REGVAL_DATA_PATH, L"");
     if (!regData.empty()) {
@@ -70,117 +101,20 @@ EnrollmentWizard::EnrollmentWizard() {
         m_username = username;
     }
 
-    // Get UPN (UserPrincipalName)
-    {
-        ULONG upnSize = 256;
-        std::vector<wchar_t> upnBuf(upnSize);
-        HMODULE hSecur32 = LoadLibraryW(L"secur32.dll");
-        if (hSecur32) {
-            typedef BOOLEAN (WINAPI *PFN_GetUserNameExW)(int, LPWSTR, PULONG);
-            auto pfn = reinterpret_cast<PFN_GetUserNameExW>(
-                GetProcAddress(hSecur32, "GetUserNameExW"));
-            if (pfn) {
-                if (pfn(8 /* NameUserPrincipal */, upnBuf.data(), &upnSize)) {
-                    m_upn = upnBuf.data();
-                } else {
-                    DWORD err = GetLastError();
-                    FACELOGIN_WARN(L"GetUserNameExW NameUserPrincipal FAILED: err=%lu", err);
-                }
-            } else {
-                FACELOGIN_ERROR(L"GetUserNameExW not found in secur32.dll");
-            }
-            // Also try NameSamCompatible to see what we get
-            {
-                ULONG samSize = 256;
-                std::vector<wchar_t> samBuf(samSize);
-                if (pfn && pfn(2 /* NameSamCompatible */, samBuf.data(), &samSize)) {
-                    // SAM-compatible name captured (not logged — may contain PII)
-                } else {
-                    DWORD err = GetLastError();
-                    FACELOGIN_WARN(L"GetUserNameExW NameSamCompatible FAILED: err=%lu", err);
-                }
-            }
-            // Try NameDisplay
-            {
-                ULONG dispSize = 256;
-                std::vector<wchar_t> dispBuf(dispSize);
-                if (pfn && pfn(3 /* NameDisplay */, dispBuf.data(), &dispSize)) {
-                    // Display name captured (not logged — may contain PII)
-                } else {
-                    DWORD err = GetLastError();
-                    FACELOGIN_WARN(L"GetUserNameExW NameDisplay FAILED: err=%lu", err);
-                }
-            }
-            FreeLibrary(hSecur32);
-        } else {
-            FACELOGIN_ERROR(L"LoadLibrary secur32.dll FAILED: err=%lu", GetLastError());
-        }
-    }
-
-    // Try reading MSA UPN from IdentityStore registry
-    // On Win10+, MSA accounts store UPN in HKLM\SOFTWARE\Microsoft\IdentityStore\...
-    {
-        // First, enumerate the IdentityStore provider GUIDs from
-        // HKLM\SOFTWARE\Microsoft\IdentityCRL\StoredIdentities\{SID}
-        // but only if we have a valid SID.
-        if (!m_sid.empty()) {
-            wchar_t storedIdentitiesPath[1024];
-            swprintf(storedIdentitiesPath, 1023,
-                     L"SOFTWARE\\Microsoft\\IdentityCRL\\StoredIdentities\\%s",
-                     m_sid.c_str());
-            HKEY hStored = nullptr;
-            if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, storedIdentitiesPath,
-                0, KEY_ENUMERATE_SUB_KEYS | KEY_QUERY_VALUE, &hStored) == ERROR_SUCCESS) {
-                wchar_t subKeyName[256];
-                DWORD idx = 0;
-                while (RegEnumKeyW(hStored, idx++, subKeyName, 256) == ERROR_SUCCESS) {
-                    wchar_t emailName[512] = {};
-                    DWORD emailSize = sizeof(emailName);
-                    RegQueryValueExW(hStored, L"UPN", nullptr, nullptr,
-                        reinterpret_cast<LPBYTE>(emailName), &emailSize);
-                    if (emailName[0] != L'\0') {
-                        if (m_upn.empty()) {
-                            m_upn = emailName;
-                        }
-                        break;
-                    }
-                }
-                RegCloseKey(hStored);
-            }
-        }
-
-        // Also try IdentityStore via the D7F9888F provider (MicrosoftAccount)
-        wchar_t idStorePath[] = L"SOFTWARE\\Microsoft\\IdentityStore\\LogonCache\\D7F9888F-E3FC-49b0-9EA6-A85B5F392A4F\\Name2Sid";
-        HKEY hIdStore = nullptr;
-        if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, idStorePath,
-            0, KEY_ENUMERATE_SUB_KEYS | KEY_QUERY_VALUE, &hIdStore) == ERROR_SUCCESS) {
-            wchar_t hashName[256];
-            DWORD idx2 = 0;
-            while (RegEnumKeyW(hIdStore, idx2++, hashName, 256) == ERROR_SUCCESS) {
-                HKEY hEntry = nullptr;
-                if (RegOpenKeyExW(hIdStore, hashName, 0, KEY_QUERY_VALUE, &hEntry) == ERROR_SUCCESS) {
-                    wchar_t identityName[256] = {};
-                    DWORD nameSize = sizeof(identityName);
-                    wchar_t sidValue[256] = {};
-                    DWORD sidSize = sizeof(sidValue);
-
-                    RegQueryValueExW(hEntry, L"IdentityName", nullptr, nullptr,
-                        reinterpret_cast<LPBYTE>(identityName), &nameSize);
-                    RegQueryValueExW(hEntry, L"Sid", nullptr, nullptr,
-                        reinterpret_cast<LPBYTE>(sidValue), &sidSize);
-
-                    if (identityName[0] != L'\0' && wcschr(identityName, L'@')) {
-                        // This is an MSA email UPN
-                        if (m_upn.empty()) {
-                            m_upn = identityName;
-                        }
-                    }
-                    RegCloseKey(hEntry);
-                }
-            }
-            RegCloseKey(hIdStore);
-        }
-    }
+    // Get UPN (UserPrincipalName) — the ONLY trusted source of the current
+    // session's identity. GetUserNameExW(NameUserPrincipal) returns the email
+    // UPN for Microsoft accounts and fails with ERROR_NONE_MAPPED for local
+    // accounts, so m_upn stays empty for local users.
+    //
+    // NOTE: machine-wide registry fallbacks (IdentityCRL\StoredIdentities,
+    // IdentityStore\LogonCache\Name2Sid) used to live here and adopted ANY
+    // cached MSA email without verifying it belongs to the current user. On
+    // machines with a leftover MSA identity (a previous user profile, or an
+    // MSA later converted to local) that mislabeled local accounts as MSA and
+    // poisoned the stored record — producing a perpetual false
+    // "账号身份已变更" prompt (docs/todo.md bug1). Never re-add an
+    // unattributed cache lookup.
+    m_upn = GetSessionUpn();
 
     // Determine account type: MSA accounts have a UPN containing '@'
     m_accountType = "local";
@@ -751,26 +685,32 @@ std::string EnrollmentWizard::GetUserUpn() const {
 }
 
 bool EnrollmentWizard::ValidatePassword(const std::wstring& password) {
-    // MSA (UPN contains '@'): LogonUserW with domain="." forces validation
-    // against only the local account database — i.e. the STALE cached MSA
-    // credential, not the user's current Microsoft password. Passing
-    // domain=NULL with a UPN lets the provider route through CloudAP for an
-    // online validation of the CURRENT password. INTERACTIVE also refreshes
-    // the cached credential when it succeeds (NETWORK never caches).
-    bool isMsa = !m_upn.empty() && m_upn.find(L'@') != std::wstring::npos;
+    // The MSA/local decision MUST come from the live session identity
+    // (GetSessionUpn), never from m_upn: m_upn used to be polluted with
+    // another account's email by a registry fallback (docs/todo.md bug1),
+    // which routed local users into the MSA path below and made the account
+    // refresh loop impossible to complete.
+    std::wstring sessionUpn = GetSessionUpn();
+    bool isMsa = !sessionUpn.empty() && sessionUpn.find(L'@') != std::wstring::npos;
 
     if (isMsa) {
+        // MSA: domain=NULL routes through CloudAP for an online validation of
+        // the CURRENT password. (LogonUserW with domain="." would validate
+        // against only the local account database — i.e. the STALE cached MSA
+        // credential, not the user's current Microsoft password.) INTERACTIVE
+        // also refreshes the cached credential when it succeeds (NETWORK
+        // never caches).
         HANDLE hToken = nullptr;
-        BOOL ok = LogonUserW(m_upn.c_str(), nullptr, password.c_str(),
+        BOOL ok = LogonUserW(sessionUpn.c_str(), nullptr, password.c_str(),
                              LOGON32_LOGON_INTERACTIVE, LOGON32_PROVIDER_DEFAULT, &hToken);
         if (ok && hToken) {
             CloseHandle(hToken);
-            FACELOGIN_INFO(L"ValidatePassword: MSA online validation OK (%s)", m_upn.c_str());
+            FACELOGIN_INFO(L"ValidatePassword: MSA online validation OK (%s)", sessionUpn.c_str());
             return true;
         }
         DWORD err = GetLastError();
         FACELOGIN_WARN(L"ValidatePassword: MSA interactive logon failed for %s (err=%lu)",
-                       m_upn.c_str(), err);
+                       sessionUpn.c_str(), err);
         return false;
     }
 
@@ -1054,37 +994,23 @@ bool EnrollmentWizard::RenameFace(int faceId, const std::wstring& label) {
     return true;
 }
 
-// Detect a stale account-type record (symmetric MSA ↔ local). The constructor's
-// MSA registry fallbacks (EnrollmentWizard.cpp:120-182) may fill m_upn with an
-// old email, so we do NOT trust m_upn/m_accountType here — we re-query the
-// current session identity instead:
-//   GetUserNameExW(8) succeeds with '@' → current account is MSA
-//   GetUserNameExW(8) fails (err 1332)  → current account is local
+// Detect a stale account-type record (symmetric MSA ↔ local). We never trust
+// m_upn/m_accountType here — they are derived from the session at construction
+// and could be empty for local accounts; instead we re-query the CURRENT
+// session identity with the authoritative GetSessionUpn() (docs/todo.md bug1):
+//   UPN contains '@'  → current account is MSA
+//   empty (err 1332)  → current account is local
 // Then compare against the stored record (matched by SID, which Windows keeps
 // across MSA↔local conversions):
 //   local + record UPN is an MSA email  → state 1 (MSA→local, clear UPN)
 //   MSA   + record UPN empty/different  → state 2 (local→MSA, write current UPN)
 //   everything else                     → state 0 (no refresh needed)
 int EnrollmentWizard::GetAccountTypeChanged() {
-    // Determine the CURRENT session's account type via NameUserPrincipal.
-    std::wstring curUpn;
-    bool sessionIsMsa = false;
-    HMODULE hSecur32 = LoadLibraryW(L"secur32.dll");
-    if (hSecur32) {
-        typedef BOOLEAN (WINAPI *PFN_GetUserNameExW)(int, LPWSTR, PULONG);
-        auto pfn = reinterpret_cast<PFN_GetUserNameExW>(
-            GetProcAddress(hSecur32, "GetUserNameExW"));
-        if (pfn) {
-            ULONG upnSize = 256;
-            std::vector<wchar_t> upnBuf(upnSize);
-            if (pfn(8 /* NameUserPrincipal */, upnBuf.data(), &upnSize)) {
-                curUpn = upnBuf.data();
-                sessionIsMsa = (curUpn.find(L'@') != std::wstring::npos);
-            }
-            // else: err 1332 (ERROR_NONE_MAPPED) = no UPN → local account.
-        }
-        FreeLibrary(hSecur32);
-    }
+    // Determine the CURRENT session's account type via the authoritative
+    // query used everywhere else (docs/todo.md bug1). Empty (err 1332) means
+    // no UPN → local account.
+    std::wstring curUpn = GetSessionUpn();
+    bool sessionIsMsa = !curUpn.empty() && curUpn.find(L'@') != std::wstring::npos;
 
     // Match the current identity against stored records (same priority as
     // FindUserIndex: SID > UPN > username).
@@ -1127,20 +1053,8 @@ std::string EnrollmentWizard::CheckAccountTypeChanged() {
     size_t faces = (idx < m_store.GetUsers().size()) ? m_store.GetUsers()[idx].faces.size() : 0;
 
     if (state == 2) {
-        // Re-derive the current MSA email (same GetUserNameExW query as above).
-        std::wstring curUpn;
-        HMODULE hSecur32 = LoadLibraryW(L"secur32.dll");
-        if (hSecur32) {
-            typedef BOOLEAN (WINAPI *PFN_GetUserNameExW)(int, LPWSTR, PULONG);
-            auto pfn = reinterpret_cast<PFN_GetUserNameExW>(
-                GetProcAddress(hSecur32, "GetUserNameExW"));
-            if (pfn) {
-                ULONG upnSize = 256;
-                std::vector<wchar_t> upnBuf(upnSize);
-                if (pfn(8, upnBuf.data(), &upnSize)) curUpn = upnBuf.data();
-            }
-            FreeLibrary(hSecur32);
-        }
+        // Re-derive the current MSA email (same authoritative query).
+        std::wstring curUpn = GetSessionUpn();
         return "{\"state\":2,\"faces\":" + std::to_string(faces) +
                ",\"upn\":\"" + WstrToUtf8Escaped(curUpn) + "\"}";
     }
@@ -1186,18 +1100,7 @@ bool EnrollmentWizard::RefreshAccountIdentity(const std::wstring& password) {
     //   state 2 (local→MSA): write the current MSA email (session UPN).
     std::wstring newUpn;
     if (state == 2) {
-        HMODULE hSecur32 = LoadLibraryW(L"secur32.dll");
-        if (hSecur32) {
-            typedef BOOLEAN (WINAPI *PFN_GetUserNameExW)(int, LPWSTR, PULONG);
-            auto pfn = reinterpret_cast<PFN_GetUserNameExW>(
-                GetProcAddress(hSecur32, "GetUserNameExW"));
-            if (pfn) {
-                ULONG upnSize = 256;
-                std::vector<wchar_t> upnBuf(upnSize);
-                if (pfn(8, upnBuf.data(), &upnSize)) newUpn = upnBuf.data();
-            }
-            FreeLibrary(hSecur32);
-        }
+        newUpn = GetSessionUpn();
     }
     // state 1 → newUpn stays empty (local account).
 
@@ -1215,6 +1118,55 @@ bool EnrollmentWizard::RefreshAccountIdentity(const std::wstring& password) {
                    m_username.c_str(),
                    newUpn.empty() ? L"<cleared>" : newUpn.c_str(),
                    state == 2 ? L", MSA" : L", local");
+    return true;
+}
+
+// Dismiss path for the stale-account prompt. Unlike RefreshAccountIdentity
+// this needs NO user input: it only drops the '@'-carrying UPN that a buggy
+// build wrote into a LOCAL account's record (docs/todo.md bug1), keeping
+// username, SID, faces and the DPAPI-encrypted password byte-for-byte intact.
+//   - state 1 (current session local + record carries an MSA email): the
+//     email is either a misattribution (another account / converted MSA) —
+//     clearing it makes the lock-screen pack domain\username, fixing the
+//     silent login failure — or a genuine MSA→local conversion where the user
+//     simply doesn't want to re-enter the password; identity is corrected and
+//     if the password changed they should still run the full refresh.
+//   - state 2 (local→MSA) is deliberately NOT touched: the record needs the
+//     CURRENT email + re-encrypted password, which only the refresh provides.
+bool EnrollmentWizard::ClearStaleAccountUpn() {
+    int state = GetAccountTypeChanged();
+    if (state != 1) {
+        FACELOGIN_INFO(L"ClearStaleAccountUpn: not a stale MSA→local record (state=%d), no-op", state);
+        return false;
+    }
+
+    std::wstring tokenSid = GetCurrentProcessUserSid();
+    m_store.LoadDatabase();
+    size_t idx = m_store.FindUserIndex(tokenSid, m_upn, m_username);
+    if (idx >= m_store.GetUsers().size()) {
+        FACELOGIN_WARN(L"ClearStaleAccountUpn: record vanished before update");
+        return false;
+    }
+    const auto& rec = m_store.GetUsers()[idx];
+    if (rec.upn.find(L'@') == std::wstring::npos) {
+        FACELOGIN_INFO(L"ClearStaleAccountUpn: record already has no MSA email, no-op");
+        return false;
+    }
+
+    // Pass the record's own encryptedPassword back unchanged so the stored
+    // credential is not re-encrypted (only the identity email is dropped).
+    if (!m_store.UpdateAccountIdentity(idx, rec.username, L"", tokenSid, rec.encryptedPassword)) {
+        FACELOGIN_ERROR(L"ClearStaleAccountUpn: identity update failed");
+        return false;
+    }
+    if (!m_store.SaveDatabase()) {
+        FACELOGIN_ERROR(L"ClearStaleAccountUpn: save failed");
+        return false;
+    }
+
+    NotifyServiceReload();
+    FACELOGIN_INFO(L"ClearStaleAccountUpn: cleared stale MSA UPN for %s (faces=%zu, password untouched)",
+                   rec.username.c_str(), rec.faces.size());
     return true;
 }
 

--- a/enrollment_app/EnrollmentWizard.h
+++ b/enrollment_app/EnrollmentWizard.h
@@ -95,6 +95,16 @@ public:
     // GetAccountTypeChanged()!=0 and the password validates.
     bool RefreshAccountIdentity(const std::wstring& password);
 
+    // Light-weight dismiss path for the stale-account prompt. State 1 only:
+    // clears the bogus MSA email from the current local account's record
+    // WITHOUT validating or re-encrypting the password (no input needed).
+    // Faces and the stored password are preserved; the lock-screen credential
+    // then packs with domain\username instead of the misattributed email.
+    // This is also the only self-heal for passwordless local accounts, whose
+    // full refresh always fails because RefreshAccountIdentity requires a
+    // non-empty password. Returns false unless the record is in state 1.
+    bool ClearStaleAccountUpn();
+
     // Configuration
     std::string GetConfig() const;
     bool SetConfig(const std::string& json);

--- a/enrollment_app/WebviewHost.cpp
+++ b/enrollment_app/WebviewHost.cpp
@@ -302,6 +302,11 @@ STDMETHODIMP HostObject::GetIDsOfNames(REFIID, LPOLESTR* names, UINT cNames, LCI
     else if (n == L"RenameFace") *ids = 29;
     else if (n == L"CheckAccountTypeChanged") *ids = 30;
     else if (n == L"RefreshAccountIdentity") *ids = 31;
+    // NOTE: DISPID 32 is skipped on main — GetCaptureStatus() is a
+    // feature/multi-angle-recognition-only method not present here. Keeping
+    // ClearStaleAccountUpn at 33 matches that branch, so the future merge
+    // slots GetCaptureStatus into 32 without renumbering.
+    else if (n == L"ClearStaleAccountUpn") *ids = 33;
     else return DISP_E_UNKNOWNNAME;
     return S_OK;
 }
@@ -438,6 +443,7 @@ STDMETHODIMP HostObject::Invoke(DISPID id, REFIID, LCID, WORD wFlags, DISPPARAMS
             if (res) *res = MakeBool(m_wizard->RefreshAccountIdentity(pass));
             break;
         }
+        case 33: if (res) *res = MakeBool(m_wizard->ClearStaleAccountUpn()); break;
         default: return DISP_E_MEMBERNOTFOUND;
         }
         return S_OK;

--- a/enrollment_app/index.html
+++ b/enrollment_app/index.html
@@ -469,6 +469,7 @@ body{
 var H = window.chrome.webview.hostObjects.sync.host;
 var viewing = true, lastB64 = '', lastFacesJson = '', timer = 0, faceImg = new Image();
 var camReady = false, currentTab = 'cam';
+var refreshState = 0;  // account-type-change state shown in the refresh modal (0/1/2)
 
 faceImg.onload = function() {
   drawBackgroundAndOverlay();
@@ -915,9 +916,11 @@ function checkAccountRefresh() {
 }
 
 function showRefreshPrompt(state, faces, upn) {
+  refreshState = state;
   var overlay = document.getElementById('refresh-overlay');
   var info = document.getElementById('refresh-info');
   var title = document.getElementById('refresh-title');
+  var dismissBtn = document.getElementById('refresh-dismiss');
   var facesText = (faces > 0) ? '你已录入 ' + faces + ' 张人脸，' : '';
   if (state === 2) {
     // local→MSA: record is local-era, now signed in with a Microsoft account.
@@ -928,13 +931,17 @@ function showRefreshPrompt(state, faces, upn) {
       + '需要刷新已保存的账号信息（人脸数据将保留），并更新微软账号密码。'
       + (upn ? '将绑定微软账号：' + upn + '。' : '')
       + '请输入当前微软账号密码。';
+    dismissBtn.textContent = '暂不处理';
   } else {
     // MSA→local: record still carries the old Microsoft email.
     title.textContent = '账号身份已变更';
     info.textContent = facesText
       + '检测到该账号曾使用微软账号（MSA）登录，现已切换为本地账号。'
       + '为使人脸登录继续生效，需要刷新已保存的账号信息（人脸数据将保留），'
-      + '并更新本地密码。请输入当前 Windows 登录密码。';
+      + '并更新本地密码。请输入当前 Windows 登录密码。'
+      + '也可点击下方「仅清理账号邮箱」立即清除残留邮箱、恢复锁屏登录'
+      + '（保留人脸与密码，但不更新已保存的密码）。';
+    dismissBtn.textContent = '仅清理账号邮箱';
   }
   document.getElementById('refresh-pass').value = '';
   overlay.classList.add('active');
@@ -971,8 +978,31 @@ function onRefreshConfirm() {
 }
 
 function onRefreshDismiss() {
-  document.getElementById('refresh-overlay').classList.remove('active');
-  showBanner('faces', '已跳过。下次进入“人脸”页仍会提示刷新账号信息。', 'ok', 6000);
+  var btn = document.getElementById('refresh-dismiss');
+  btn.disabled = true;
+  // Defer the synchronous COM call so the disabled state paints first.
+  setTimeout(function() {
+    btn.disabled = false;
+    document.getElementById('refresh-overlay').classList.remove('active');
+    if (refreshState !== 1) {
+      // state 2 (local→MSA) needs the refresh to write the current email and
+      // re-encrypt the password — there is nothing safe to auto-clean.
+      showBanner('faces', '已暂不处理。下次进入“人脸”页仍会提示刷新账号信息。', 'ok', 6000);
+      return;
+    }
+    // state 1 (MSA→local): clear the stale MSA email so the lock-screen stops
+    // packing the misattributed identity — faces and the stored password are
+    // preserved. The full "刷新" path remains the right choice if the Windows
+    // password changed since enrollment.
+    var ok = false;
+    try { ok = H.ClearStaleAccountUpn(); } catch(e) { ok = false; }
+    if (ok) {
+      showBanner('faces', '已清理残留的账号邮箱，人脸已保留，锁屏登录将改用本地账号身份。若密码已更改，请改用「刷新并保留人脸」。', 'ok', 6000);
+      loadFaces();
+    } else {
+      showBanner('faces', '清理未完成。请点击「刷新并保留人脸」验证密码，或删除该录入后重新录入。', 'error', 6000);
+    }
+  }, 50);
 }
 
 // Show the append-face confirmation screen (current account already has faces).

--- a/enrollment_app/index.html
+++ b/enrollment_app/index.html
@@ -469,7 +469,11 @@ body{
 var H = window.chrome.webview.hostObjects.sync.host;
 var viewing = true, lastB64 = '', lastFacesJson = '', timer = 0, faceImg = new Image();
 var camReady = false, currentTab = 'cam';
-var refreshState = 0;  // account-type-change state shown in the refresh modal (0/1/2)
+// The account-type-change state (0/1/2) is stashed on #refresh-overlay's
+// dataset rather than a module-level var so the dismiss handler always reads
+// the state captured AT OPEN TIME of THIS prompt — a later showRefreshPrompt()
+// (e.g. a re-check while the modal is up) can't race the 50ms deferred
+// dismiss callback and flip it to a different branch.
 
 faceImg.onload = function() {
   drawBackgroundAndOverlay();
@@ -916,8 +920,8 @@ function checkAccountRefresh() {
 }
 
 function showRefreshPrompt(state, faces, upn) {
-  refreshState = state;
   var overlay = document.getElementById('refresh-overlay');
+  overlay.dataset.refreshState = String(state);  // snapshot at open time
   var info = document.getElementById('refresh-info');
   var title = document.getElementById('refresh-title');
   var dismissBtn = document.getElementById('refresh-dismiss');
@@ -980,11 +984,17 @@ function onRefreshConfirm() {
 function onRefreshDismiss() {
   var btn = document.getElementById('refresh-dismiss');
   btn.disabled = true;
+  // Snapshot the state captured when THIS prompt opened. Reading it inside
+  // the deferred callback (rather than a shared module var) avoids a TOCTOU
+  // where a re-check while the modal is up overwrites the state and sends
+  // the dismiss down the wrong branch.
+  var overlay = document.getElementById('refresh-overlay');
+  var state = parseInt(overlay.dataset.refreshState || '0', 10);
   // Defer the synchronous COM call so the disabled state paints first.
   setTimeout(function() {
     btn.disabled = false;
-    document.getElementById('refresh-overlay').classList.remove('active');
-    if (refreshState !== 1) {
+    overlay.classList.remove('active');
+    if (state !== 1) {
       // state 2 (local→MSA) needs the refresh to write the current email and
       // re-encrypt the password — there is nothing safe to auto-clean.
       showBanner('faces', '已暂不处理。下次进入“人脸”页仍会提示刷新账号信息。', 'ok', 6000);

--- a/scripts/unregister_dev.bat
+++ b/scripts/unregister_dev.bat
@@ -1,0 +1,140 @@
+@echo off
+setlocal enabledelayedexpansion
+
+REM ============================================================================
+REM FaceLogin - Unregister dev credential provider
+REM
+REM Undoes what scripts\start_standalone.bat did, so the "Face Login" tile
+REM stops appearing on the lock screen:
+REM   1. Kills any running FaceLoginService (standalone process / SCM service)
+REM   2. Unregisters the credential provider DLL (regsvr32 /u)
+REM   3. Removes leftover registry registrations (safety net -- regsvr32 /u
+REM      can't run if the DLL is already gone, and reg delete covers that)
+REM   4. Deletes the credential provider DLL from System32
+REM   5. Cleans up runtime registry keys under HKLM\SOFTWARE\FaceLogin
+REM
+REM Every step is ALSO appended to %TEMP%\FaceLogin_unregister.log, so if the
+REM window flashes closed again you can read the log to see exactly how far the
+REM script got before dying.
+REM
+REM This is a dev-cleanup script only -- it does NOT touch the formal
+REM installer (FaceLoginSetup.exe). Re-run scripts\start_standalone.bat to
+REM re-register for testing.
+REM
+REM (NOTE: keep this file pure-ASCII -- cmd.exe on a GBK codepage chokes on
+REM  multi-byte UTF-8 chars like em-dash and the whole script silently mis-parses.)
+REM ============================================================================
+
+set "LOG=%TEMP%\FaceLogin_unregister.log"
+> "%LOG%" echo FaceLogin unregister started: %DATE% %TIME%
+
+REM ---- Admin self-check ----
+net session >nul 2>&1
+if %errorlevel% neq 0 (
+    call :note "[ERROR] This script must be run as Administrator."
+    call :note "Right-click the .bat and choose 'Run as administrator'."
+    echo.
+    pause
+    exit /b 1
+)
+
+echo.
+echo ============================================
+echo   FaceLogin - Unregister Dev Credential Provider
+echo ============================================
+echo.
+
+set "DLL=%SystemRoot%\System32\FaceLoginCredentialProvider.dll"
+set "CLSID={B8F4C7A1-3D5E-4F2B-A9C6-1D8E7F3A5B2C}"
+set "CPKEY=HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Authentication\Credential Providers\%CLSID%"
+set "CLSIDKEY=HKLM\SOFTWARE\Classes\CLSID\%CLSID%"
+
+REM ---- [1/5] Kill all running FaceLoginService instances ----
+call :note "[1/5] Killing FaceLoginService instances..."
+taskkill /F /IM FaceLoginService.exe >nul 2>&1
+if !errorlevel! equ 0 (
+    call :note "  Killed running instance(s)."
+) else (
+    call :note "  No running instance found (ok)."
+)
+sc stop FaceLoginService >nul 2>&1
+sc delete FaceLoginService >nul 2>&1
+REM Sleep WITHOUT timeout.exe -- timeout can abort the whole batch when stdin
+REM is redirected. ping never fails, so it can't kill the script.
+ping -n 3 127.0.0.1 >nul
+
+REM ---- [2/5] Unregister credential provider DLL ----
+call :note "[2/5] Unregistering credential provider DLL..."
+if exist "%DLL%" (
+    regsvr32 /s /u "%DLL%"
+    if !errorlevel! equ 0 (
+        call :note "  Unregistered successfully."
+    ) else (
+        call :note "  [WARNING] regsvr32 /u returned error !errorlevel!."
+        call :note "  Registry keys will be removed manually next."
+    )
+) else (
+    call :note "  [WARNING] %DLL% not found -- keys removed manually next."
+)
+
+REM ---- [3/5] Remove leftover registry registrations (safety net) ----
+call :note "[3/5] Removing leftover registry registrations..."
+reg delete "%CLSIDKEY%" /f >nul 2>&1
+if !errorlevel! equ 0 (
+    call :note "  Removed CLSID key."
+) else (
+    call :note "  CLSID key already gone (ok)."
+)
+reg delete "%CPKEY%" /f >nul 2>&1
+if !errorlevel! equ 0 (
+    call :note "  Removed Credential Providers key."
+) else (
+    call :note "  Credential Providers key already gone (ok)."
+)
+
+REM ---- [4/5] Delete credential provider DLL from System32 ----
+call :note "[4/5] Deleting credential provider DLL from System32..."
+if exist "%DLL%" (
+    del /F "%DLL%" >nul 2>&1
+    if !errorlevel! equ 0 (
+        call :note "  Deleted %DLL%"
+    ) else (
+        call :note "  [ERROR] Could not delete %DLL%."
+        call :note "  LogonUI / the lock screen may still be holding it. Log off"
+        call :note "  fully or reboot, then delete it manually: del %DLL%"
+    )
+) else (
+    call :note "  Already absent (ok)."
+)
+
+REM ---- [5/5] Clean up runtime registry keys (optional) ----
+call :note "[5/5] Cleaning up runtime registry key HKLM\SOFTWARE\FaceLogin..."
+reg delete "HKLM\SOFTWARE\FaceLogin" /f >nul 2>&1
+if !errorlevel! equ 0 (
+    call :note "  Removed runtime registry key."
+) else (
+    call :note "  No runtime key found (ok)."
+)
+
+REM ---- Verify ----
+reg query "%CLSIDKEY%" >nul 2>&1
+if !errorlevel! equ 0 (
+    call :note "[VERIFY] CLSID registration STILL PRESENT -- something went wrong."
+) else (
+    call :note "[VERIFY] CLSID registration removed. Tile should be gone from lock screen."
+)
+
+echo.
+echo  Log written to: %LOG%
+echo ============================================
+echo  Done. The "Face Login" tile will no longer
+echo  appear on the lock screen.
+echo ============================================
+echo.
+pause
+exit /b 0
+
+:note
+echo %~1
+echo %~1>> "%LOG%"
+exit /b 0


### PR DESCRIPTION
## 背景

在多用户/MSA 曾登录过的机器上，注册控制台（`FaceLoginConsole.exe`）每次进入都误报"账号身份已变更"，且账号刷新流程永远失败，污染的 UPN 流到凭据打包还会导致锁屏人脸登录静默失败。

本 PR 分两步修复：先修根因（`e1448dd`），再修补根因修复中引入的 4 处新问题（`4d68c43`）。

## 改动 1：修复 MSA 身份误判根因（`e1448dd`）

**根因**：`EnrollmentWizard` 构造函数从机器级注册表缓存（`IdentityStore\LogonCache\Name2Sid`、`IdentityCRL\StoredIdentities`）无条件采纳任意带 `@` 的 MSA 邮箱，**未校验该邮箱是否属于当前用户**。机器上残留的其他账户 MSA 身份（旧用户配置文件、或后来转为本地的 MSA）会被错误贴到当前本地账户记录上，污染 UPN。

**修复**：
- 构造器删除两段无归属校验的注册表兜底，`m_upn` 只来自 `GetUserNameExW(NameUserPrincipal)` —— 它对 MSA 返回邮箱、对本地账户失败（`ERROR_NONE_MAPPED`），是当前会话身份的唯一权威来源。
- 新增 `GetSessionUpn()` 统一会话身份查询，`ValidatePassword` / `GetAccountTypeChanged` / `CheckAccountTypeChanged` / `RefreshAccountIdentity` 全部改用它。
- `ValidatePassword` 改用会话身份判断 MSA/本地，刷新流程可正常走本地 SAM 验证。
- 凭据提供程序 `GetMSAUpnFromIdentityStore` 补上 **SID 归属校验**：只有缓存邮箱关联的 SID 与请求用户 SID 一致才采纳，杜绝 A 用户拿到 B 用户邮箱的身份混淆。
- 新增 `ClearStaleAccountUpn`：弹窗"仅清理账号邮箱"按钮，自动清除残留 UPN（保留人脸与加密密码），修复无密码账户陷入刷新死循环的问题。

## 改动 2：修补修复中引入的安全/健壮性问题（`4d68c43`）

代码审查 `e1448dd` 时发现 4 处新问题，一并修复：

### 🟠 中危

| # | 位置 | 问题 | 修复 |
|---|------|------|------|
| 1 | `GetSessionUpn()` | 只用 256 wchar 探测一次，缓冲区不足时直接放弃 → 超长 UPN（很长域名 / AD UPN）被静默丢弃并误判为本地账户，**与 bug1 同一问题的对称情况** | `ERROR_INSUFFICIENT_BUFFER` 时按返回大小 `resize` 重试一次 |
| 2 | `WstrToUtf8Escaped()` | 只转义 `"` 和 `\`，未处理控制字符 → UPN 含 `\n` `\r` 等时前端 `JSON.parse` 失败（潜在 JSON 注入） | 按 RFC 8259 补全 `\b \f \n \r \t` 及 `U+0000–001F` 用 `\u00XX` |

### 🟡 低危

| # | 位置 | 问题 | 修复 |
|---|------|------|------|
| 3 | `ClearStaleAccountUpn()` | `FindUserIndex` 传入被污染的 `m_upn`，语义自相矛盾（要清的值用来定位记录） | 改传 `L""`，仅靠进程令牌 SID + username 匹配 |
| 4 | `index.html` | 模块级全局变量 `refreshState`，dismiss 的 50ms 延迟回调存在 TOCTOU（延迟期间若弹窗被重新触发，状态被改写） | 改为存到 `#refresh-overlay.dataset`，dismiss 时读取打开时刻的快照 |

## 验证

- ✅ CMake Release 编译通过（`FaceLoginConsole.exe`），仅有既有的、与本次改动无关的 `C4005` 警告（`WINVER`/`_WIN32_WINNT` 重定义，来自 `webcam_capture.h`）。
- 跑 `FaceLoginConsole.exe` 后不会再触发该问题。
- 需要在 MSA↔本地账户切换场景下确认不再误报。

## 风险

- 改动集中在身份判定与 JSON 序列化，行为变化都是收紧（不再信任未校验的缓存、转义更严格），向后兼容。
- `ClearStaleAccountUpn` 服务端有 `GetAccountTypeChanged()` 二次校验兜底，前端传错的 state 也不会误清数据。